### PR TITLE
Add dependency caching to GitHub workflow

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,15 +9,13 @@ jobs:
     runs-on: self-hosted
     steps:
     - uses: actions/checkout@v4
-    - name: Cache pip dependencies
+    - name: Cache virtual environment
       uses: actions/cache@v4
       with:
-        path: |
-          ~/.cache/pip
-          venv
-        key: ${{ runner.os }}-pip-${{ hashFiles('**/pyproject.toml') }}
+        path: venv
+        key: ${{ runner.os }}-venv-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
-          ${{ runner.os }}-pip-
+          ${{ runner.os }}-venv-
     - name: Install dependencies
       run: ./script/setup
     - name: Run lint


### PR DESCRIPTION
## Summary
- Add caching for the virtual environment in the lint workflow to speed up dependency installation
- Cache only the venv directory to avoid conflicts on self-hosted runners
- Cache key based on OS and pyproject.toml hash for proper invalidation

This should significantly reduce the 25-second dependency installation time on cache hits.