### PR TITLE
Create a global settings (vibe-kanban)

### DIFF
--- a/.ai_recordings/agent.json
+++ b/.ai_recordings/agent.json
@@ -1,5 +1,5 @@
 {
-  "db5db9d41ca21e66bd173e3cdde6d73a4b2c75f9": [
+  "e0dfc08cfe7835a5df3c3842cd7b1e00cd605b10": [
     "You should say goodbye to the world!",
     [
       

--- a/.ai_recordings/agent.json
+++ b/.ai_recordings/agent.json
@@ -1,5 +1,5 @@
 {
-  "cb924966ab3c0a0036e71e58b364a87af3faea5a": [
-    "You should say goodbye to the World!",
+  "db5db9d41ca21e66bd173e3cdde6d73a4b2c75f9": [
+    "You should say goodbye to the world!",
     [
       

--- a/.ai_recordings/ai.json
+++ b/.ai_recordings/ai.json
@@ -1,4 +1,4 @@
 {
   "ebddf5bc2de5eab6edb12406bb818b62178ed7e8": "Mocked AI response",
-  "46fe656241d5085ec1148159f985d0fca2ed7236": "Why did the scarecrow win an award?\n\nBecause he was outstanding in his field!"
+  "46fe656241d5085ec1148159f985d0fca2ed7236": "Why did the scarecrow win an award? \n\nBecause he was outstanding in his field!"
 }

--- a/.ai_recordings/ai.json
+++ b/.ai_recordings/ai.json
@@ -1,4 +1,4 @@
 {
   "ebddf5bc2de5eab6edb12406bb818b62178ed7e8": "Mocked AI response",
-  "46fe656241d5085ec1148159f985d0fca2ed7236": "Why did the scarecrow win an award? \n\nBecause he was outstanding in his field!"
+  "46fe656241d5085ec1148159f985d0fca2ed7236": "Why did the scarecrow win an award?\n\nBecause he was outstanding in his field!"
 }

--- a/project.yml
+++ b/project.yml
@@ -1,0 +1,6 @@
+languages:
+  - en
+  - ru
+  - fr
+translate_from: jp
+translate_to: en

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,8 @@ dependencies = [
     "pyright",
     "langchain",
     "langchain-community",
-    "langchain-openai"
+    "langchain-openai",
+    "pyyaml"
 ]
 readme = "README.md"
 

--- a/src/helpers/settings.py
+++ b/src/helpers/settings.py
@@ -1,0 +1,55 @@
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Any, Dict, List, cast
+
+import yaml
+
+
+@dataclass
+class Settings:
+    languages: List[str]
+    translate_from: str
+    translate_to: str
+
+
+@lru_cache(maxsize=1)
+def settings() -> Settings:
+    project_file = os.path.join(os.getcwd(), "project.yml")
+    if not os.path.exists(project_file):
+        raise FileNotFoundError(f"project.yml not found in {os.getcwd()}")
+
+    with open(project_file, "r") as f:
+        data = cast(Dict[str, Any], yaml.safe_load(f))
+
+    languages = data.get("languages")
+    translate_from = data.get("translate_from")
+    translate_to = data.get("translate_to")
+
+    if languages is None or translate_from is None or translate_to is None:
+        raise ValueError(
+            "project.yml must contain 'languages', 'translate_from', and 'translate_to'"
+        )
+
+    if not isinstance(languages, list) or not all(
+        isinstance(lang, str) for lang in languages
+    ):
+        raise ValueError("'languages' must be a list of strings")
+
+    if not isinstance(translate_from, str):
+        raise ValueError("'translate_from' must be a string")
+
+    if not isinstance(translate_to, str):
+        raise ValueError("'translate_to' must be a string")
+
+    if translate_from in languages:
+        raise ValueError("'translate_from' must not be in 'languages'")
+
+    if translate_to not in languages:
+        raise ValueError("'translate_to' must be in 'languages'")
+
+    return Settings(
+        languages=cast(List[str], languages),
+        translate_from=translate_from,
+        translate_to=translate_to,
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,160 @@
+import os
+from pathlib import Path
+
+import pytest
+import yaml
+
+from src.helpers.settings import settings
+
+
+@pytest.fixture(autouse=True)
+def clear_cache():
+    settings.cache_clear()
+    yield
+
+
+def test_settings_success(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", "ru", "fr"],
+        "translate_from": "jp",
+        "translate_to": "en",
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    result = settings()
+    assert result.languages == ["en", "ru", "fr"]
+    assert result.translate_from == "jp"
+    assert result.translate_to == "en"
+
+
+def test_settings_memoization(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", "ru"],
+        "translate_from": "jp",
+        "translate_to": "en",
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    result1 = settings()
+    result2 = settings()
+    assert result1 is result2
+
+
+def test_settings_file_not_found(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    with pytest.raises(FileNotFoundError, match="project.yml not found"):
+        settings()
+
+
+def test_settings_missing_languages(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {"translate_from": "jp", "translate_to": "en"}
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="must contain 'languages'"):
+        settings()
+
+
+def test_settings_missing_translate_from(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {"languages": ["en", "ru"], "translate_to": "en"}
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="must contain 'languages', 'translate_from', and 'translate_to'"):
+        settings()
+
+
+def test_settings_missing_translate_to(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {"languages": ["en", "ru"], "translate_from": "jp"}
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="must contain 'languages', 'translate_from', and 'translate_to'"):
+        settings()
+
+
+def test_settings_invalid_languages_type(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {"languages": "en ru", "translate_from": "jp", "translate_to": "en"}
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="'languages' must be a list of strings"):
+        settings()
+
+
+def test_settings_languages_not_strings(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", 123],
+        "translate_from": "jp",
+        "translate_to": "en",
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="'languages' must be a list of strings"):
+        settings()
+
+
+def test_settings_translate_from_not_string(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", "ru"],
+        "translate_from": 123,
+        "translate_to": "en",
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="'translate_from' must be a string"):
+        settings()
+
+
+def test_settings_translate_to_not_string(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", "ru"],
+        "translate_from": "jp",
+        "translate_to": 123,
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="'translate_to' must be a string"):
+        settings()
+
+
+def test_settings_translate_from_in_languages(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", "ru", "jp"],
+        "translate_from": "jp",
+        "translate_to": "en",
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="'translate_from' must not be in 'languages'"):
+        settings()
+
+
+def test_settings_translate_to_not_in_languages(tmp_path: Path):
+    os.chdir(str(tmp_path))
+    project_yml = {
+        "languages": ["en", "ru"],
+        "translate_from": "jp",
+        "translate_to": "fr",
+    }
+    with open("project.yml", "w") as f:
+        yaml.dump(project_yml, f)
+
+    with pytest.raises(ValueError, match="'translate_to' must be in 'languages'"):
+        settings()


### PR DESCRIPTION
We need to have a global settings() method available to anyone in the system. 

settings() should have the following properties:

languages: list of languages (like ["en", "ru", ...])
translate_from: string, should not be one of languages
translate_to: string, should be one of languages

Put it into src/helpers/settings.py

Settings should load all this from `project.yml` from the current folder once called and should memoise this. 

If there is no project or at least one of the properties is not present -- it should immidiately throw