### PR TITLE
Create a TranslationString object (vibe-kanban)

### DIFF
--- a/.ai_recordings/agent.json
+++ b/.ai_recordings/agent.json
@@ -1,5 +1,5 @@
 {
-  "cb924966ab3c0a0036e71e58b364a87af3faea5a": [
-    "You should say goodbye to the World!",
+  "5a223f12c7759a5afb8c5907b6921fba73f05937": [
+    "You should say goodbye to the world!",
     [
       

--- a/src/models/translation_string.py
+++ b/src/models/translation_string.py
@@ -1,0 +1,75 @@
+import json
+from typing import Any, Dict, List, Optional
+
+
+class TranslationString:
+    def __init__(
+        self, original_text: str, original_language: str, available_languages: List[str]
+    ):
+        self.original_text = original_text
+        self.original_language = original_language
+        self.available_languages = available_languages
+        self.translations: Dict[str, str] = {}
+
+    def __getattr__(self, name: str) -> Optional[str]:
+        if name == self.original_language:
+            return self.original_text
+        return self.translations.get(name, None)
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if name in [
+            "original_text",
+            "original_language",
+            "available_languages",
+            "translations",
+        ]:
+            object.__setattr__(self, name, value)
+        elif name in self.available_languages:
+            self.translations[name] = value
+        else:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute '{name}'"
+            )
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, TranslationString):
+            return (
+                self.original_text == other.original_text
+                and self.original_language == other.original_language
+                and self.available_languages == other.available_languages
+                and self.translations == other.translations
+            )
+        if isinstance(other, str):
+            if other == self.original_text:
+                return True
+            return other in self.translations.values()
+        return False
+
+    def __str__(self) -> str:
+        return self.original_text
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "original_text": self.original_text,
+            "original_language": self.original_language,
+            "available_languages": self.available_languages,
+            "translations": self.translations,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "TranslationString":
+        obj = cls(
+            data["original_text"],
+            data["original_language"],
+            data["available_languages"],
+        )
+        obj.translations = data["translations"]
+        return obj
+
+    def to_json(self) -> str:
+        return json.dumps(self.to_dict())
+
+    @classmethod
+    def from_json(cls, json_str: str) -> "TranslationString":
+        data = json.loads(json_str)
+        return cls.from_dict(data)

--- a/tests/test_translation_string.py
+++ b/tests/test_translation_string.py
@@ -1,0 +1,116 @@
+import pytest
+
+from src.models.translation_string import TranslationString
+
+
+def test_initialization():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    assert s.original_text == "Cat"
+    assert s.original_language == "en"
+    assert s.available_languages == ["ru", "ua"]
+    assert s.translations == {}
+
+
+def test_get_original_language():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    assert s.en == "Cat"
+
+
+def test_equality_with_original():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    assert s == "Cat"
+    assert "Cat" == s
+
+
+def test_print():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    assert str(s) == "Cat"
+
+
+def test_set_translation():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    s.ru = "Кот"
+    assert s.ru == "Кот"
+
+
+def test_equality_with_translation():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    s.ru = "Кот"
+    assert s == "Кот"
+    assert s == "Cat"  # Still true
+
+
+def test_unset_translation_returns_none():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    assert s.ua is None
+
+
+def test_invalid_language_assignment():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    with pytest.raises(AttributeError):
+        s.ge = "Kitten"
+
+
+def test_serialization():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    s.ru = "Кот"
+    data = s.to_dict()
+    expected = {
+        "original_text": "Cat",
+        "original_language": "en",
+        "available_languages": ["ru", "ua"],
+        "translations": {"ru": "Кот"},
+    }
+    assert data == expected
+
+
+def test_deserialization():
+    data = {
+        "original_text": "Cat",
+        "original_language": "en",
+        "available_languages": ["ru", "ua"],
+        "translations": {"ru": "Кот"},
+    }
+    s = TranslationString.from_dict(data)
+    assert s.original_text == "Cat"
+    assert s.en == "Cat"
+    assert s.ru == "Кот"
+    assert s.ua is None
+
+
+def test_json_serialization():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    s.ru = "Кот"
+    json_str = s.to_json()
+    s2 = TranslationString.from_json(json_str)
+    assert s2 == s
+    assert s2.en == "Cat"
+    assert s2.ru == "Кот"
+
+
+def test_equality_false():
+    s = TranslationString(
+        "Cat", original_language="en", available_languages=["ru", "ua"]
+    )
+    assert (s == "Dog") is False
+    assert (s == 123) is False


### PR DESCRIPTION
We need to store an string with all it's possible translations. 

To do it, create a python object which will be able to hold them. 

Syntax:

```
s = TranslationString("Cat", original_language="en", available_languages=['ru', 'ua'])

s.en # should return "Cat"
s == "Cat" # Should return True
print(s) # Should print Cat

s.ru = "Кот" 
s.ru # Should return "Кот"
s == "Кот" #Should return True, but s == "Cat" should ALSO return true
print(s) # Still should print Cat

s.ge = "Kitten" # Should throw: ge is not in the list of available languages

s.ua # Should return None: we did not assigned anything yet
```

Put it into src/models/translation_string.py

TranslationString should be serialiseable / deserialiseable to json form

Don't forget to cover it with tests. 