### PR TITLE
demo mode does not work... (vibe-kanban)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -130,7 +130,7 @@ def handle_character_command(args: argparse.Namespace, api_key: Optional[str]) -
         log_error("API key required for character operations")
         return
 
-    from fantranslate.tools.character import (  # type: ignore
+    from tools.character import (  # type: ignore
         add_character_short_name,
         create_character,
         search_character,
@@ -158,7 +158,7 @@ def handle_demo(api_key: Optional[str]) -> None:
 
     log_info("Running character management demo")
 
-    from fantranslate.tools.character import (  # type: ignore
+    from tools.character import (  # type: ignore
         create_character,
         get_character_translation,
         search_character,


### PR DESCRIPTION
```
./script/fantranslate demo
Traceback (most recent call last):
  File "/Users/trousev/prog/fantranslate/venv/bin/fantranslate", line 7, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/trousev/prog/fantranslate/src/main.py", line 106, in main
    handle_demo(api_key)
    ~~~~~~~~~~~^^^^^^^^^
  File "/Users/trousev/prog/fantranslate/src/main.py", line 161, in handle_demo
    from fantranslate.tools.character import (  # type: ignore
    ...<3 lines>...
    )
ModuleNotFoundError: No module named 'fantranslate'
```