### PR TITLE
Imports to the top please (vibe-kanban)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -134,6 +134,16 @@ The `AgentExecutor` in `src/ai.py` has `verbose=False` by default. Our custom tr
 
 If LangChain's verbose mode is ever needed for debugging specific LangChain issues, the `verbose` parameter can be temporarily set to `True`, but our custom tracing should be used for all production logging.
 
+## Import Organization
+
+- **All imports must be at the top of the file**: Do not place import statements inside functions, classes, or anywhere else in the code. All imports should be grouped at the beginning of the file, after any module docstrings but before any executable code.
+- **Import order**: Follow the standard Python import order:
+  1. Standard library imports
+  2. Third-party imports
+  3. Local imports (from the current package)
+- **Use isort**: The `./script/lint` command runs `isort` which automatically sorts and organizes imports according to the configuration in `pyproject.toml`.
+- **Avoid conditional imports**: Do not use imports inside `if` statements or try/except blocks unless absolutely necessary for optional dependencies.
+
 ## Conventions
 
 - Use type hints where possible.

--- a/src/ai_test_helpers.py
+++ b/src/ai_test_helpers.py
@@ -5,7 +5,7 @@ import os
 import sys
 from typing import Any, Callable, Dict
 
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
+from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage  # type: ignore[reportUnusedImport]
 from langchain.tools import BaseTool
 
 

--- a/src/ai_test_helpers.py
+++ b/src/ai_test_helpers.py
@@ -5,7 +5,10 @@ import os
 import sys
 from typing import Any, Callable, Dict
 
-from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage  # type: ignore[reportUnusedImport]
+from langchain.schema import AIMessage  # type: ignore[reportUnusedImport]
+from langchain.schema import HumanMessage  # type: ignore[reportUnusedImport]
+from langchain.schema import SystemMessage  # type: ignore[reportUnusedImport]
+from langchain.schema import BaseMessage
 from langchain.tools import BaseTool
 
 

--- a/src/ai_test_helpers.py
+++ b/src/ai_test_helpers.py
@@ -5,7 +5,7 @@ import os
 import sys
 from typing import Any, Callable, Dict
 
-from langchain.schema import BaseMessage
+from langchain.schema import AIMessage, BaseMessage, HumanMessage, SystemMessage
 from langchain.tools import BaseTool
 
 

--- a/src/main.py
+++ b/src/main.py
@@ -18,6 +18,16 @@ from tracing import (
     set_log_level,
 )
 
+from ai import ai, agent
+from tools.character import (
+    add_character_short_name,
+    create_character,
+    get_character_translation,
+    search_character,
+    set_character_gender,
+)
+from tools.hello import hello_tool
+
 
 def main():
     parser = argparse.ArgumentParser(description="FanTranslate CLI")
@@ -114,7 +124,6 @@ def main():
         # Original behavior
         if api_key:
             log_info("API key loaded successfully")
-            from ai import ai
 
             log_enter("ai_call")
             joke = ai("You are a comedian.", "Tell me a funny joke not about science.")
@@ -136,13 +145,6 @@ def handle_character_command(args: argparse.Namespace, api_key: Optional[str]) -
         log_error("API key required for character operations")
         return
 
-    from tools.character import (  # type: ignore
-        add_character_short_name,
-        create_character,
-        search_character,
-        set_character_gender,
-    )
-
     if args.char_command == "create":
         result = create_character(args.name, args.gender)
         print(f"Created character: {result}")
@@ -163,12 +165,6 @@ def handle_demo(api_key: Optional[str]) -> None:
         return
 
     log_info("Running character management demo")
-
-    from tools.character import (  # type: ignore
-        create_character,
-        get_character_translation,
-        search_character,
-    )
 
     # Create a character
     result = create_character("Frodo Baggins", "male")
@@ -193,9 +189,6 @@ def handle_agent_command(agent_name: str, api_key: Optional[str]) -> None:
         return
 
     if agent_name == "demo_agent":
-        from ai import agent
-        from tools.hello import hello_tool
-
         log_info("Running demo agent")
         output, _ = agent(
             system_prompt="You are a helpful assistant that can use tools to greet people.",

--- a/src/main.py
+++ b/src/main.py
@@ -8,6 +8,15 @@ from typing import Optional
 
 from dotenv import load_dotenv
 
+from ai import agent, ai
+from tools.character import (
+    add_character_short_name,
+    create_character,
+    get_character_translation,
+    search_character,
+    set_character_gender,
+)
+from tools.hello import hello_tool
 from tracing import (
     LogLevel,
     log_enter,
@@ -17,16 +26,6 @@ from tracing import (
     log_trace,
     set_log_level,
 )
-
-from ai import ai, agent
-from tools.character import (
-    add_character_short_name,
-    create_character,
-    get_character_translation,
-    search_character,
-    set_character_gender,
-)
-from tools.hello import hello_tool
 
 
 def main():

--- a/src/models/character_collection.py
+++ b/src/models/character_collection.py
@@ -4,6 +4,7 @@ import yaml
 
 from helpers.fuzzy import FuzzyIndex
 from helpers.settings import settings  # type: ignore
+
 from .character import Character, TranslatedCharacter
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,10 +1,12 @@
 import json
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
 from ai import agent, ai, yesno
+from main import main
+from tools.hello import hello_tool
 
 
 def test_ai_memoisation():
@@ -16,8 +18,6 @@ def test_ai_memoisation():
         pytest.skip("Skipping memoisation test in recordings mode")
 
     with patch("ai.get_client") as mock_get_client:
-        from unittest.mock import MagicMock
-
         mock_client = MagicMock()
         mock_response = MagicMock()
         mock_response.choices = [MagicMock()]
@@ -55,7 +55,6 @@ def test_ai_memoisation():
 
 def test_agent_basic():
     # Test that the agent function works
-    from tools.hello import hello_tool
 
     # Test the agent with the hello tool
     system_prompt = "You are a helpful assistant. Use tools when appropriate."
@@ -74,7 +73,6 @@ def test_agent_basic():
 
 def test_agent_with_chat_history():
     # Test that previous chat history influences the agent output
-    from tools.hello import hello_tool
 
     system_prompt = "You are a helpful assistant. Use tools when appropriate."
     tools = [hello_tool]
@@ -99,8 +97,6 @@ def test_agent_with_chat_history():
 
 def test_main_runs_without_error():
     # Test that main() runs without error (recording system handles determinism)
-    from main import main
-
     try:
         main()
     except Exception as e:

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -4,14 +4,13 @@ from pathlib import Path
 import pytest
 import yaml
 
+import helpers.settings
 from helpers.settings import settings
 
 
 @pytest.fixture(autouse=True)
 def clear_settings_cache():
     # Reset the cached settings before each test
-    import helpers.settings
-
     helpers.settings.__settings = None  # type: ignore
     yield
 


### PR DESCRIPTION
I don't like when imports are in the middle of the file / function

Put them always in the top in all our codebase. 

Ensure that we have some linter which ensures this for future. 