### PR TITLE
Ability to get all characters (vibe-kanban)

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -73,6 +73,9 @@ def main():
         "gender", choices=["male", "female", "other"], help="Gender"
     )
 
+    # List all characters
+    char_subparsers.add_parser("list", help="List all characters")
+
     # Demo workflow
     subparsers.add_parser("demo", help="Run character management demo")
 
@@ -139,6 +142,7 @@ def handle_character_command(args: argparse.Namespace, api_key: Optional[str]) -
     from tools.character import (  # type: ignore
         add_character_short_name,
         create_character,
+        get_all_characters,
         search_character,
         set_character_gender,
     )
@@ -155,6 +159,9 @@ def handle_character_command(args: argparse.Namespace, api_key: Optional[str]) -
     elif args.char_command == "set_gender":
         result = set_character_gender(args.name, args.gender)
         print(f"Set gender: {result}")
+    elif args.char_command == "list":
+        result = get_all_characters()
+        print(result)
 
 
 def handle_demo(api_key: Optional[str]) -> None:

--- a/src/models/character_collection.py
+++ b/src/models/character_collection.py
@@ -4,6 +4,7 @@ import yaml
 
 from helpers.fuzzy import FuzzyIndex
 from helpers.settings import settings  # type: ignore
+
 from .character import Character, TranslatedCharacter
 
 
@@ -51,6 +52,10 @@ class CharacterCollection:
         if not character:
             return None
         return character.get_translated(language)
+
+    def get_all_characters(self, language: str) -> List[TranslatedCharacter]:
+        """Get all characters translated to the specified language."""
+        return [char.get_translated(language) for char in self.characters]
 
     def to_dict(self) -> List[Dict[str, Any]]:
         return [char.to_dict() for char in self.characters]

--- a/src/tools/character.py
+++ b/src/tools/character.py
@@ -97,6 +97,27 @@ def get_character_translation(input_str: str) -> str:
         return f"Error getting translation: {str(e)}"
 
 
+def get_all_characters() -> str:
+    """Get all characters in the system. Returns XML with name, short_names, and gender only."""
+    s = settings()
+    characters = character_collection.get_all_characters(s.translate_from)
+
+    xml_parts = ["<characters>"]
+    for char in characters:
+        xml_parts.append("<character>")
+        xml_parts.append(f"<name>{char.name}</name>")
+        xml_parts.append("<short_names>")
+        for sn in char.short_names:
+            xml_parts.append(f"<short_name>{sn}</short_name>")
+        xml_parts.append("</short_names>")
+        if char.gender:
+            xml_parts.append(f"<gender>{char.gender}</gender>")
+        xml_parts.append("</character>")
+    xml_parts.append("</characters>")
+
+    return "".join(xml_parts)
+
+
 search_character_tool = Tool(
     name="SearchCharacter",
     description="Search for an existing character by name or short name using fuzzy matching.",
@@ -127,10 +148,17 @@ get_character_translation_tool = Tool(
     func=get_character_translation,
 )
 
+get_all_characters_tool = Tool(
+    name="GetAllCharacters",
+    description="Get a list of all characters in the system with their names, short names, and genders.",
+    func=get_all_characters,
+)
+
 character_tools: List[Tool] = [
     search_character_tool,
     create_character_tool,
     add_short_name_tool,
     set_gender_tool,
     get_character_translation_tool,
+    get_all_characters_tool,
 ]

--- a/tests/test_character_collection.py
+++ b/tests/test_character_collection.py
@@ -98,3 +98,21 @@ def test_from_file_classmethod():
 
     finally:
         os.unlink(temp_file)
+
+
+def test_get_all_characters():
+    collection = CharacterCollection()
+    char1 = Character("Alice", short_names=["Al"], gender="female")
+    char2 = Character("Bob", gender="male")
+    collection.add_character(char1)
+    collection.add_character(char2)
+
+    all_characters = collection.get_all_characters("en")
+
+    assert len(all_characters) == 2
+    assert all_characters[0].name == "Alice"
+    assert all_characters[0].short_names == ["Al"]
+    assert all_characters[0].gender == "female"
+    assert all_characters[1].name == "Bob"
+    assert all_characters[1].short_names == []
+    assert all_characters[1].gender == "male"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -6,6 +6,7 @@ from tools.character import (
     add_character_short_name,
     character_tools,
     create_character,
+    get_all_characters,
     get_character_translation,
     search_character,
     set_character_gender,
@@ -22,13 +23,14 @@ def test_hello_tool():
 
 def test_character_tools():
     """Test that character tools are defined."""
-    assert len(character_tools) == 5
+    assert len(character_tools) == 6
     names = [tool.name for tool in character_tools]
     assert "SearchCharacter" in names
     assert "CreateCharacter" in names
     assert "AddCharacterShortName" in names
     assert "SetCharacterGender" in names
     assert "GetCharacterTranslation" in names
+    assert "GetAllCharacters" in names
 
 
 @patch("models.character.settings")
@@ -123,3 +125,30 @@ def test_get_character_translation(
     result = get_character_translation(json.dumps(trans_data))
     # Since no translations added, should return original
     assert "Frodo Baggins" in result
+
+
+@patch("tools.character.settings")
+@patch("models.character.settings")
+@patch("models.character_collection.settings")
+def test_get_all_characters(
+    mock_tools_settings: MagicMock,
+    mock_character_settings: MagicMock,
+    mock_collection_settings: MagicMock,
+) -> None:
+    """Test getting all characters."""
+    settings_obj = Settings(
+        languages=["en", "ru", "fr"], translate_from="jp", translate_to="en"
+    )
+    mock_collection_settings.return_value = settings_obj
+    mock_character_settings.return_value = settings_obj
+    mock_tools_settings.return_value = settings_obj
+    # Create characters first
+    create_character("Frodo Baggins", "male")
+    create_character("Gandalf", "male")
+    result = get_all_characters()
+    assert "<characters>" in result
+    assert "<character>" in result
+    assert "Frodo Baggins" in result
+    assert "Gandalf" in result
+    # Should not contain characteristics
+    assert "<characteristics>" not in result


### PR DESCRIPTION
I feel we're missing an option to list *all* available characters in the system. 

Add it both for API and as AI tool. AI tool should output only the "list of characters" -- only name, short names and gender, not characteristic. Of course in XML. 