### PR TITLE
pipe is not working when we're in wrong folder (vibe-kanban)

### DIFF
--- a/src/helpers/context.py
+++ b/src/helpers/context.py
@@ -1,6 +1,8 @@
 import os
 from typing import Dict, List, Optional
 
+from helpers.settings import RESOURCE_DIR
+
 
 class Context:
     def __init__(self, parts: Optional[List[Dict[str, str]]] = None) -> None:
@@ -24,10 +26,7 @@ class Context:
 
     def pipe(self, filename: str) -> "Context":
         """Read content from a markdown file in the prompts directory and add it to context."""
-        # Calculate the project root directory relative to this file's location
-        # src/helpers/context.py -> src/helpers -> src -> project_root
-        base_dir = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
-        filepath = os.path.join(base_dir, "prompts", f"{filename}.md")
+        filepath = os.path.join(RESOURCE_DIR, "prompts", f"{filename}.md")
         with open(filepath, "r", encoding="utf-8") as f:
             content = f.read()
         new_parts = self.parts + [{"type": "pipe", "content": content}]

--- a/src/helpers/settings.py
+++ b/src/helpers/settings.py
@@ -6,6 +6,9 @@ import yaml
 
 DEFAULT_CHARACTERS_STORAGE = "characters.yml"
 
+# Directory containing application resource files (prompts, etc.)
+RESOURCE_DIR = os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+
 
 @dataclass
 class Settings:


### PR DESCRIPTION
```
./script/fantranslate -v extract_characters test_chapters/01.txt
ENTER: main
  INFO: Log level set to DEBUG
  INFO: Extracting characters from chapter: test_chapters/01.txt
  ENTER: extract_characters_from_chapter
    INFO: Loaded 1 existing characters
    ENTER: detection_judge
      ERROR: Error during character extraction: [Errno 2] No such file or directory: 'prompts/detection_judge.md'
    EXIT: extract_characters_from_chapter
Character extraction failed or incomplete
```

This happens because fantranslate is called NOT from our project's root folder. 

Can we introduce some robust resource management so fantranslate (and it's `pipe` method of context manager) will always find our app's text resources