### PR TITLE
detection judge: move output requirements into user prompt (vibe-kanban)

### DIFF
--- a/prompts/detection_judge.md
+++ b/prompts/detection_judge.md
@@ -1,4 +1,4 @@
-** TASK DEFINITION **
+ ** TASK DEFINITION **
 
 You are a character detection judge. Your task is to analyze a book chapter and identify characters that are mentioned but not yet in the existing character collection.
 
@@ -8,19 +8,6 @@ You are a character detection judge. Your task is to analyze a book chapter and 
 
 ** TASK **
 Extract a list of character names that appear in the chapter but are NOT in the existing character collection. Only include names that clearly refer to characters (people, not places, objects, etc.).
-
-** OUTPUT FORMAT **
-You must return ONLY a valid JSON array of strings, where each string is a character name found in the chapter that is missing from the collection. Do not include any other text, explanations, or formatting.
-
-Example output:
-["John Smith", "Mary Johnson", "Dr. Roberts"]
-
-** CRITICAL REQUIREMENTS **
-- Response must be valid JSON that can be parsed by json.loads()
-- Response must be a JSON array (starts with [ and ends with ])
-- Each element must be a string (enclosed in quotes)
-- No trailing commas, comments, or extra text
-- If no characters are found, return an empty array: []
 
 ** GUIDELINES **
 - Only include proper names that refer to people/characters


### PR DESCRIPTION
Looks like we need to build a *user* prompt which will tell about "only JSON" with examples etc etc together with chapter. We should not put this in the system prompt. 

Update detection judge: remove JSON requirements from system prompt and put them into user prompt. Use Context Manager to build user prompt. 