### PR TITLE
The Narrator Problem (vibe-kanban)

### DIFF
--- a/prompts/completeness_judge.md
+++ b/prompts/completeness_judge.md
@@ -13,6 +13,9 @@ Answer YES if all missing characters have been successfully added to the collect
 - YES: Every character from the missing list appears in the all characters list (by name or short name)
 - NO: One or more characters from the missing list are not found in the all characters
 
+** SPECIAL CONSIDERATION: NARRATOR CHARACTERS **
+Note that narrator characters may have "Narrator" added as a short name. This does not change the matching logic - characters should still be matched by their primary name or any of their short names.
+
 ** OUTPUT FORMAT **
 - YES (if complete)
 - NO, [brief reason] (if incomplete)

--- a/prompts/completeness_judge.md
+++ b/prompts/completeness_judge.md
@@ -14,7 +14,10 @@ Answer YES if all missing characters have been successfully added to the collect
 - NO: One or more characters from the missing list are not found in the all characters
 
 ** SPECIAL CONSIDERATION: NARRATOR CHARACTERS **
-Note that narrator characters may have "Narrator" added as a short name. This does not change the matching logic - characters should still be matched by their primary name or any of their short names.
+Note that narrator characters may have "Narrator" added as a short name. Characters should be matched by their primary name or any of their short names.
+
+** SPECIAL CONSIDERATION: NAME CHANGES **
+If a character was originally named "Narrator" but had their name changed to a real name during extraction, the character should be considered successfully extracted if their new real name appears in the collection.
 
 ** OUTPUT FORMAT **
 - YES (if complete)

--- a/prompts/detection_judge.md
+++ b/prompts/detection_judge.md
@@ -1,4 +1,4 @@
- ** TASK DEFINITION **
+** TASK DEFINITION **
 
 You are a character detection judge. Your task is to analyze a book chapter and identify characters that are mentioned but not yet in the existing character collection.
 
@@ -9,9 +9,42 @@ You are a character detection judge. Your task is to analyze a book chapter and 
 ** TASK **
 Extract a list of character names that appear in the chapter but are NOT in the existing character collection. Only include names that clearly refer to characters (people, not places, objects, etc.).
 
+** SPECIAL CASE: NARRATOR CHARACTERS **
+Handle narrator characters with these rules:
+
+1. **Named Narrator**: If the narrator appears to be one of the characters in the story (e.g., first-person narration where "I" refers to a character, or third-person limited narration where the narrator focuses on one character's perspective), include that character's actual name in the list. The extraction process will handle adding "Narrator" as a short name.
+
+2. **Unnamed Narrator**: If the narrator's identity cannot be determined (no clear character name revealed, but narration is clearly from a first-person or limited third-person perspective), include "Narrator" as the character name in the list.
+
+3. **Name Revelation**: If a character was previously identified as "Narrator" but their real name is revealed in this chapter, include their real name in the list. The extraction process will handle renaming them and adding "Narrator" as a short name.
+
+** DETECTING NARRATOR CHARACTERS **
+Look for these patterns to identify narrator characters:
+- First-person narration: The character uses "I", "my", "me", "we", "our", "us" to refer to themselves
+- Third-person limited: The story focuses heavily on one character's thoughts, feelings, and perspective
+- The character appears in most scenes and has detailed internal monologue
+- The character is the central figure around whom the plot revolves
+- No clear character name is given, but narration suggests a specific character's viewpoint
+
+** OUTPUT FORMAT **
+You must return ONLY a valid JSON array of strings, where each string is a character name found in the chapter that is missing from the collection. Do not include any other text, explanations, or formatting.
+
+Example output:
+["John Smith", "Mary Johnson", "Dr. Roberts"]
+
+** CRITICAL REQUIREMENTS **
+- Response must be valid JSON that can be parsed by json.loads()
+- Response must be a JSON array (starts with [ and ends with ])
+- Each element must be a string (enclosed in quotes)
+- No trailing commas, comments, or extra text
+- If no characters are found, return an empty array: []
+
 ** GUIDELINES **
 - Only include proper names that refer to people/characters
 - Include both full names and nicknames if they appear
 - Do not include place names, object names, or abstract concepts
 - If a character is already in the collection (by any of their names or short names), do not include them
 - Be thorough but avoid false positives
+- For named narrator characters, include their actual name in the output list
+- For unnamed narrators, include "Narrator" as the character name
+- For name revelations, include the newly revealed real name in the output list

--- a/prompts/extraction_agent.md
+++ b/prompts/extraction_agent.md
@@ -13,6 +13,9 @@ For each missing character, use the available character tools to:
 3. Set the character's gender if mentioned
 4. Extract and add characteristics (descriptions, traits, relationships) from the text
 
+** SPECIAL HANDLING: NARRATOR CHARACTERS **
+If a character appears to be the narrator of the story (e.g., first-person narration where the character refers to themselves as "I"), automatically add "Narrator" as one of their short names using the AddCharacterShortName tool.
+
 ** AVAILABLE TOOLS **
 - SearchCharacter: Search for an existing character by name or short name using fuzzy matching
 - CreateCharacter: Create a new character with the provided information
@@ -28,3 +31,4 @@ For each missing character, use the available character tools to:
 - Add multiple characteristics if available (appearance, personality, relationships, etc.)
 - If gender is not mentioned, leave it as default
 - Focus on factual information from the text, not inferences
+- Always check if a character is the narrator and add "Narrator" as a short name when appropriate

--- a/prompts/extraction_agent.md
+++ b/prompts/extraction_agent.md
@@ -14,7 +14,17 @@ For each missing character, use the available character tools to:
 4. Extract and add characteristics (descriptions, traits, relationships) from the text
 
 ** SPECIAL HANDLING: NARRATOR CHARACTERS **
-Analyze the chapter text to determine if any of the missing characters are narrators. If a character appears to be the narrator, automatically add "Narrator" as one of their short names using the AddCharacterShortName tool.
+Handle narrator characters with these specific rules:
+
+1. **Named Narrator**: If a character in the missing list appears to be the narrator, create them normally and add "Narrator" as a short name.
+
+2. **Unnamed Narrator**: If "Narrator" appears in the missing characters list, create a character named "Narrator" with appropriate characteristics based on the narration style.
+
+3. **Name Revelation**: If a character name appears in the missing list and you discover this is actually the real name of a character previously known as "Narrator", you need to:
+   - First check if "Narrator" already exists in the collection
+   - If it does, update that character's name to the new real name
+   - Add "Narrator" as a short name for the character
+   - Continue with normal character extraction
 
 ** DETECTING NARRATOR CHARACTERS **
 Look for these patterns in the chapter text:
@@ -30,11 +40,19 @@ When you identify a narrator character:
 2. Immediately use AddCharacterShortName to add "Narrator" as a short name
 3. Continue with normal character extraction (gender, characteristics, etc.)
 
+** PROCESSING NAME CHANGES **
+When handling name revelations:
+1. Use SearchCharacter to find if "Narrator" exists in the collection
+2. If "Narrator" exists, use UpdateCharacterName to change their name to the real name
+3. Use AddCharacterShortName to add "Narrator" as a short name for the character
+4. Extract any additional information (gender, characteristics) from the chapter
+
 ** AVAILABLE TOOLS **
 - SearchCharacter: Search for an existing character by name or short name using fuzzy matching
 - CreateCharacter: Create a new character with the provided information
 - AddCharacterShortName: Add a short name to an existing character
 - SetCharacterGender: Set the gender of an existing character
+- UpdateCharacterName: Update the name of an existing character
 - GetCharacterTranslation: Get character information translated to the specified language
 - GetAllCharacters: Get a list of all characters in the system with their names, short names, and genders
 

--- a/prompts/extraction_agent.md
+++ b/prompts/extraction_agent.md
@@ -14,7 +14,21 @@ For each missing character, use the available character tools to:
 4. Extract and add characteristics (descriptions, traits, relationships) from the text
 
 ** SPECIAL HANDLING: NARRATOR CHARACTERS **
-If a character appears to be the narrator of the story (e.g., first-person narration where the character refers to themselves as "I"), automatically add "Narrator" as one of their short names using the AddCharacterShortName tool.
+Analyze the chapter text to determine if any of the missing characters are narrators. If a character appears to be the narrator, automatically add "Narrator" as one of their short names using the AddCharacterShortName tool.
+
+** DETECTING NARRATOR CHARACTERS **
+Look for these patterns in the chapter text:
+- First-person narration: The character uses "I", "my", "me", "we", "our", "us" to refer to themselves
+- Third-person limited: The story focuses heavily on one character's thoughts, feelings, and perspective
+- The character appears in most scenes and has detailed internal monologue
+- The character is the central figure around whom the plot revolves
+- The narrative voice matches the character's personality and knowledge
+
+** PROCESSING NARRATOR CHARACTERS **
+When you identify a narrator character:
+1. Create the character normally with their full information
+2. Immediately use AddCharacterShortName to add "Narrator" as a short name
+3. Continue with normal character extraction (gender, characteristics, etc.)
 
 ** AVAILABLE TOOLS **
 - SearchCharacter: Search for an existing character by name or short name using fuzzy matching

--- a/src/extract_characters.py
+++ b/src/extract_characters.py
@@ -1,4 +1,5 @@
 import json
+import re
 from typing import List, Tuple
 
 from ai import agent, ai, yesno
@@ -22,6 +23,50 @@ extraction_tools = [
     set_gender_tool,
     get_all_characters_tool,
 ]
+
+
+def detect_narrator_characters(
+    missing_characters: List[str], chapter_text: str
+) -> List[str]:
+    """Detect which missing characters are narrators based on the chapter text.
+
+    Args:
+        missing_characters: List of character names to check
+        chapter_text: The full text of the book chapter
+
+    Returns:
+        List of character names that appear to be narrators
+    """
+    log_enter("detect_narrator_characters")
+
+    narrator_characters: List[str] = []
+
+    # Simple heuristic: if a character is referred to with first-person pronouns
+    # in contexts where they are the subject, they might be the narrator
+    for character_name in missing_characters:
+        # Look for patterns like "I [verb]" or "my [noun]" near the character name
+        # This is a simple heuristic - the AI agent will make the final determination
+        name_pattern = re.escape(character_name)
+        first_person_patterns = [
+            rf"{name_pattern}.*?\bI\b",
+            rf"\bI\b.*?\b{re.escape(character_name.split()[0])}\b",  # First name after "I"
+            rf"{name_pattern}.*?\bmy\b",
+            rf"{name_pattern}.*?\bme\b",
+        ]
+
+        is_potential_narrator = False
+        for pattern in first_person_patterns:
+            if re.search(pattern, chapter_text, re.IGNORECASE):
+                is_potential_narrator = True
+                break
+
+        if is_potential_narrator:
+            narrator_characters.append(character_name)
+            log_info(f"Detected potential narrator character: {character_name}")
+
+    log_info(f"Detected {len(narrator_characters)} potential narrator characters")
+    log_exit("detect_narrator_characters")
+    return narrator_characters
 
 
 def detection_judge(
@@ -164,14 +209,24 @@ def extraction_agent(
     """
     log_enter("extraction_agent")
 
+    # Detect potential narrator characters
+    narrator_characters = detect_narrator_characters(missing_characters, chapter_text)
+
     # Build the prompt using Context
+    missing_chars_text = (
+        "The following characters need to be extracted from the chapter:\n"
+        + "\n".join(f"- {name}" for name in missing_characters)
+    )
+
+    if narrator_characters:
+        missing_chars_text += (
+            f"\n\n**NARRATOR CHARACTERS**: The following characters appear to be narrators and should have 'Narrator' added as a short name:\n"
+            + "\n".join(f"- {name}" for name in narrator_characters)
+        )
+
     context = (
         Context()
-        .add(
-            "Missing Characters",
-            "The following characters need to be extracted from the chapter:\n"
-            + "\n".join(f"- {name}" for name in missing_characters),
-        )
+        .add("Missing Characters", missing_chars_text)
         .add("Chapter Text", chapter_text)
         .pipe("extraction_agent")
     )

--- a/src/extract_characters.py
+++ b/src/extract_characters.py
@@ -1,5 +1,4 @@
 import json
-import re
 from typing import List, Tuple
 
 from ai import agent, ai, yesno
@@ -23,50 +22,6 @@ extraction_tools = [
     set_gender_tool,
     get_all_characters_tool,
 ]
-
-
-def detect_narrator_characters(
-    missing_characters: List[str], chapter_text: str
-) -> List[str]:
-    """Detect which missing characters are narrators based on the chapter text.
-
-    Args:
-        missing_characters: List of character names to check
-        chapter_text: The full text of the book chapter
-
-    Returns:
-        List of character names that appear to be narrators
-    """
-    log_enter("detect_narrator_characters")
-
-    narrator_characters: List[str] = []
-
-    # Simple heuristic: if a character is referred to with first-person pronouns
-    # in contexts where they are the subject, they might be the narrator
-    for character_name in missing_characters:
-        # Look for patterns like "I [verb]" or "my [noun]" near the character name
-        # This is a simple heuristic - the AI agent will make the final determination
-        name_pattern = re.escape(character_name)
-        first_person_patterns = [
-            rf"{name_pattern}.*?\bI\b",
-            rf"\bI\b.*?\b{re.escape(character_name.split()[0])}\b",  # First name after "I"
-            rf"{name_pattern}.*?\bmy\b",
-            rf"{name_pattern}.*?\bme\b",
-        ]
-
-        is_potential_narrator = False
-        for pattern in first_person_patterns:
-            if re.search(pattern, chapter_text, re.IGNORECASE):
-                is_potential_narrator = True
-                break
-
-        if is_potential_narrator:
-            narrator_characters.append(character_name)
-            log_info(f"Detected potential narrator character: {character_name}")
-
-    log_info(f"Detected {len(narrator_characters)} potential narrator characters")
-    log_exit("detect_narrator_characters")
-    return narrator_characters
 
 
 def detection_judge(
@@ -209,24 +164,14 @@ def extraction_agent(
     """
     log_enter("extraction_agent")
 
-    # Detect potential narrator characters
-    narrator_characters = detect_narrator_characters(missing_characters, chapter_text)
-
     # Build the prompt using Context
-    missing_chars_text = (
-        "The following characters need to be extracted from the chapter:\n"
-        + "\n".join(f"- {name}" for name in missing_characters)
-    )
-
-    if narrator_characters:
-        missing_chars_text += (
-            f"\n\n**NARRATOR CHARACTERS**: The following characters appear to be narrators and should have 'Narrator' added as a short name:\n"
-            + "\n".join(f"- {name}" for name in narrator_characters)
-        )
-
     context = (
         Context()
-        .add("Missing Characters", missing_chars_text)
+        .add(
+            "Missing Characters",
+            "The following characters need to be extracted from the chapter:\n"
+            + "\n".join(f"- {name}" for name in missing_characters),
+        )
         .add("Chapter Text", chapter_text)
         .pipe("extraction_agent")
     )

--- a/src/tools/character.py
+++ b/src/tools/character.py
@@ -85,6 +85,19 @@ def set_character_gender(name: str, gender: str) -> str:
         return f"Error setting gender: {str(e)}"
 
 
+def update_character_name(current_name: str, new_name: str) -> str:
+    """Update the name of an existing character. Input: current character name, new name."""
+    try:
+        character = character_collection.search(current_name)
+        if not character:
+            return f"Character '{current_name}' not found"
+        character.update(name=new_name)
+        character_collection._rebuild_index()  # type: ignore
+        return f"Name of character changed from '{current_name}' to '{new_name}'"
+    except Exception as e:
+        return f"Error updating character name: {str(e)}"
+
+
 def get_character_translation(input_str: str) -> str:
     """Get character information translated to a language. Input: JSON with name and language."""
     try:
@@ -145,6 +158,12 @@ set_gender_tool = Tool(
     func=set_character_gender,
 )
 
+update_name_tool = Tool(
+    name="UpdateCharacterName",
+    description="Update the name of an existing character.",
+    func=update_character_name,
+)
+
 get_character_translation_tool = Tool(
     name="GetCharacterTranslation",
     description="Get character information translated to the specified language.",
@@ -162,6 +181,7 @@ character_tools: List[Tool] = [
     create_character_tool,
     add_short_name_tool,
     set_gender_tool,
+    update_name_tool,
     get_character_translation_tool,
     get_all_characters_tool,
 ]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -10,6 +10,7 @@ from tools.character import (
     get_character_translation,
     search_character,
     set_character_gender,
+    update_character_name,
 )
 from tools.hello import hello_tool
 
@@ -23,12 +24,13 @@ def test_hello_tool():
 
 def test_character_tools():
     """Test that character tools are defined."""
-    assert len(character_tools) == 6
+    assert len(character_tools) == 7
     names = [tool.name for tool in character_tools]
     assert "SearchCharacter" in names
     assert "CreateCharacter" in names
     assert "AddCharacterShortName" in names
     assert "SetCharacterGender" in names
+    assert "UpdateCharacterName" in names
     assert "GetCharacterTranslation" in names
     assert "GetAllCharacters" in names
 
@@ -102,6 +104,23 @@ def test_set_character_gender(
     create_character("Frodo Baggins", "male")
     result = set_character_gender("Frodo Baggins", "female")
     assert "Gender of character 'Frodo Baggins' set to 'female'" in result
+
+
+@patch("models.character.settings")
+@patch("models.character_collection.settings")
+def test_update_character_name(
+    mock_collection_settings: MagicMock, mock_character_settings: MagicMock
+) -> None:
+    """Test updating character name."""
+    settings_obj = Settings(
+        languages=["en", "ru", "fr"], translate_from="jp", translate_to="en"
+    )
+    mock_collection_settings.return_value = settings_obj
+    mock_character_settings.return_value = settings_obj
+    # Create character first
+    create_character("Narrator", "unknown")
+    result = update_character_name("Narrator", "John Smith")
+    assert "Name of character changed from 'Narrator' to 'John Smith'" in result
 
 
 @patch("tools.character.settings")


### PR DESCRIPTION
Sometimes narrator is one of the characters. 

In this case it should be detected and processed with his character's name, but one of his short names should be "Narrator".

Modify existing prompts and logic to satisfy this requirement. 