### PR TITLE
The Narrator Problem (vibe-kanban)

### DIFF
--- a/prompts/detection_judge.md
+++ b/prompts/detection_judge.md
@@ -9,9 +9,10 @@ You are a character detection judge. Your task is to analyze a book chapter and 
 ** TASK **
 Extract a list of character names that appear in the chapter but are NOT in the existing character collection. Only include names that clearly refer to characters (people, not places, objects, etc.).
 
-** GUIDELINES **
+ ** GUIDELINES **
 - Only include proper names that refer to people/characters
 - Include both full names and nicknames if they appear
 - Do not include place names, object names, or abstract concepts
 - If a character is already in the collection (by any of their names or short names), do not include them
 - Be thorough but avoid false positives
+- **NARRATOR HANDLING**: If the narrator appears to be a character in the story (speaking, acting, or being described as a character), include "Narrator" in the missing characters list. This allows the narrator to be processed as a character with "Narrator" as one of their short names.

--- a/prompts/extraction_agent.md
+++ b/prompts/extraction_agent.md
@@ -21,10 +21,11 @@ For each missing character, use the available character tools to:
 - GetCharacterTranslation: Get character information translated to the specified language
 - GetAllCharacters: Get a list of all characters in the system with their names, short names, and genders
 
-** GUIDELINES **
+ ** GUIDELINES **
 - Be thorough in extracting character information
 - Only create characters that are explicitly listed as missing
 - Use the chapter text as the source of truth for all character information
 - Add multiple characteristics if available (appearance, personality, relationships, etc.)
 - If gender is not mentioned, leave it as default
 - Focus on factual information from the text, not inferences
+- **NARRATOR HANDLING**: When creating a character named "Narrator", always add "Narrator" as a short name. If the narrator has a real name discovered in the text, use that as the primary name and keep "Narrator" as a short name. If no real name is found, use "Narrator" as the primary character name.


### PR DESCRIPTION
Sometimes narrator is one of the characters. 

In this case it should be detected and processed with his character's name, but one of his short names should be "Narrator".

Modify existing prompts  to satisfy this requirement.  I want this to be purely prompt engineered without code modifications. 

I also want to point to a special case: if narrator don't have a name (yet) -- it's ok as a last resort to name character "Narrator". However, when he gets a name -- it's OK to change name to a real one keeping Narrator as one of short names. 