### PR TITLE
Short names should have more space (vibe-kanban)

### DIFF
--- a/playground/test_chapter.txt
+++ b/playground/test_chapter.txt
@@ -1,0 +1,7 @@
+John Smith walked into the room. He was a tall man with brown hair. His wife, Mary Johnson, followed behind him. They were meeting with Dr. Roberts, the family physician.
+
+"Welcome," said Dr. Roberts. "Please have a seat."
+
+John nodded and sat down. Mary smiled nervously. "Thank you, Doctor," she said.
+
+Dr. Roberts opened his notebook. "Now, what brings you here today?"

--- a/src/commands/character.py
+++ b/src/commands/character.py
@@ -36,15 +36,15 @@ def handle_list(args: argparse.Namespace) -> None:
 
         # Print table
         if characters:
-            print(f"{'Name':<20} {'Short Names':<20} {'Gender':<10} {'Chars'}")
-            print("-" * 70)
+            print(f"{'Name':<20} {'Short Names':<35} {'Gender':<10} {'Chars'}")
+            print("-" * 85)
             for char in characters:
                 short_names = ", ".join(char.short_names) if char.short_names else ""
                 name = char.name[:19] if len(char.name) > 19 else char.name
-                short = short_names[:19] if len(short_names) > 19 else short_names
+                short = short_names[:34] if len(short_names) > 34 else short_names
                 gender = (char.gender or "")[:9]
                 print(
-                    f"{name:<20} {short:<20} {gender:<10} {len(char.characteristics)}"
+                    f"{name:<20} {short:<35} {gender:<10} {len(char.characteristics)}"
                 )
 
     except Exception as e:


### PR DESCRIPTION
Look at this:

```
./script/fantranslate character list
Name                 Short Names          Gender     Chars
----------------------------------------------------------------------
Frodo Baggins        Frodo                           0
Harry James Potter   Harry, The Boy-Who-  MALE       0
John Potter          John, The Boy-Who-L  MALE       0
Dursleys             Dursleys             UNKNOWN    0
Voldemort            Tom Riddle, Dark Lo  MALE       0
Dumbledore           Albus, Headmaster    MALE       0
Ginny Weasley        Ginny                FEMALE     0
Fate                 Fate                 FEMALE     0
Death                Death                MALE       0
Daphne Greengrass    Daphne               FEMALE     0
Mister Potter        Mister Potter        MALE       0
Miss Weasley         Miss Weasley         FEMALE     0
John Potter          John                 MALE       0
Fate                 Fate                 FEMALE     0
Death                Death                MALE       0
John Potter          John                 UNKNOWN    0
Fate                 Fate                 FEMALE     0
Death                Death                MALE       0
Mister Potter        Mister Potter        MALE       0
Miss Weasley         Ginny                FEMALE     0
John Potter          John                 UNKNOWN    0
Fate                 Fate                 FEMALE     0
Death                Death                MALE       0
Mister Potter        Mister Potter        MALE       0
Miss Weasley         Ginny                FEMALE     0

```

Clearly we could assign much more space for list of short names, right?