### PR TITLE
Short names should never duplicate full name (vibe-kanban)

### DIFF
--- a/src/commands/character.py
+++ b/src/commands/character.py
@@ -153,6 +153,12 @@ def handle_edit(args: argparse.Namespace) -> None:
         # Handle short name additions/removals
         if args.add_short_name:
             for name in args.add_short_name:
+                # Check if short name exactly matches the full name
+                if name.strip().lower() == character.name.original_text.strip().lower():
+                    print(
+                        f"Error: Short name '{name}' cannot be the same as the character's full name '{character.name.original_text}'. Short names should be abbreviations or alternative forms, not duplicates of the full name."
+                    )
+                    continue
                 character.add_short_name(name)
                 print(f"Added short name: {name}")
                 modified = True
@@ -315,11 +321,25 @@ def handle_create(args: argparse.Namespace) -> None:
             return
 
         # Create new character
+        # Filter out short names that match the full name
+        from typing import List, Union
+
         from models.character import Character
+        from models.translation_string import TranslationString
+
+        filtered_short_names: List[Union[str, TranslationString]] = []
+        if args.short_name:
+            for sn in args.short_name:
+                if sn.strip().lower() == args.name.strip().lower():
+                    print(
+                        f"Warning: Skipping short name '{sn}' as it matches the character's full name '{args.name}'. Short names should be abbreviations or alternative forms, not duplicates of the full name."
+                    )
+                else:
+                    filtered_short_names.append(sn)
 
         character = Character(
             name=args.name,
-            short_names=args.short_name or [],
+            short_names=filtered_short_names,
             gender=args.gender,
             characteristics=args.characteristic or [],
         )

--- a/src/tools/character.py
+++ b/src/tools/character.py
@@ -121,6 +121,11 @@ def add_character_short_name(name: str, short_name: str) -> str:
         character = character_collection.search(name)
         if not character:
             return f"Error adding short name: Character '{name}' not found in collection. Available characters: {[c.name.original_text for c in character_collection.characters]}"
+
+        # Check if short name exactly matches the full name
+        if short_name.strip().lower() == character.name.original_text.strip().lower():
+            return f"Error adding short name: Short name '{short_name}' cannot be the same as the character's full name '{character.name.original_text}'. Short names should be abbreviations or alternative forms, not duplicates of the full name."
+
         character.add_short_name(short_name)
         character_collection._rebuild_index()  # type: ignore
         return f"Short name '{short_name}' added to character '{name}' successfully"

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -89,6 +89,24 @@ def test_add_character_short_name(
 
 @patch("models.character.settings")
 @patch("models.character_collection.settings")
+def test_add_character_short_name_duplicate_full_name(
+    mock_collection_settings: MagicMock, mock_character_settings: MagicMock
+) -> None:
+    """Test that adding a short name that matches the full name is rejected."""
+    settings_obj = Settings(
+        languages=["en", "ru", "fr"], translate_from="jp", translate_to="en"
+    )
+    mock_collection_settings.return_value = settings_obj
+    mock_character_settings.return_value = settings_obj
+    # Create character first
+    create_character("Dumbledore", "male")
+    result = add_character_short_name("Dumbledore", "Dumbledore")
+    assert "cannot be the same as the character's full name" in result
+    assert "Error adding short name" in result
+
+
+@patch("models.character.settings")
+@patch("models.character_collection.settings")
 def test_set_character_gender(
     mock_collection_settings: MagicMock, mock_character_settings: MagicMock
 ) -> None:


### PR DESCRIPTION
Look at this:

```
./script/fantranslate character list
Name                 Short Names          Gender     Chars
----------------------------------------------------------------------
John Potter          John, Johnny         MALE       0
Fate                 Fate                 FEMALE     0
Death                Death                MALE       0
Dumbledore           Dumbledore, The Hea  MALE       0
Ginny Weasley        Ginny                FEMALE     0
Daphne Greengrass    Daphne               FEMALE     0
Hermione Granger     Hermione             FEMALE     0
```

 Dumbledore has the same name in short name as well!

Forbid this on tool level. If tool is trying to add a short name which is EXACTLY a full one -- it should return failure but explain this failure to LLM